### PR TITLE
waveshare_ble400: added stlink programmer

### DIFF
--- a/boards/waveshare_ble400.json
+++ b/boards/waveshare_ble400.json
@@ -22,6 +22,16 @@
             "-f", "scripts/target/nrf51.cfg"
           ]
         }
+      },
+      "stlink": {
+        "server": {
+          "package": "tool-openocd",
+          "executable": "bin/openocd",
+          "arguments": [
+            "-f", "scripts/interface/stlink-v2.cfg",
+            "-f", "scripts/target/nrf51.cfg"
+          ]
+        }
       }
     }
   },


### PR DESCRIPTION
example output:

```
GNU ARM Eclipse 64-bits Open On-Chip Debugger 0.10.0-00114-g8419536 (2017-04-18-22:28)
Licensed under GNU GPL v2
For bug reports, read
http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "hla_swd". To override use 'transport select <transport>'.
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
adapter speed: 1000 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : clock speed 950 kHz
Info : STLINK v2 JTAG v17 API v2 SWIM v4 VID 0x0483 PID 0x3748
Info : using stlink api v2
Info : Target voltage: 3.249304
Info : nrf51.cpu: hardware has 4 breakpoints, 2 watchpoints

target halted due to debug-request, current mode: Thread
xPSR: 0xc1000000 pc: 0x000006d0 msp: 0x000007c0
** Programming Started **
auto erase enabled
Warn : Unknown device (HWID 0x000000d1)
Info : Padding image section 0 with 2112 bytes
Info : Padding image section 1 with 5864 bytes
Warn : using fast async flash loader. This is currently supported
Warn : only with ST-Link and CMSIS-DAP. If you have issues, add
Warn : "set WORKAREASIZE 0" before sourcing nrf51.cfg to disable it
target halted due to breakpoint, current mode: Thread
xPSR: 0x61000000 pc: 0x2000001e msp: 0x000007c0
wrote 129024 bytes from file .pioenvs/waveshare_ble400/firmware.hex in 5.985116s (21.052 KiB/s)
** Programming Finished **
** Verify Started **
target halted due to breakpoint, current mode: Thread
xPSR: 0x61000000 pc: 0x2000002e msp: 0x000007c0
target halted due to breakpoint, current mode: Thread
xPSR: 0x61000000 pc: 0x2000002e msp: 0x000007c0
target halted due to breakpoint, current mode: Thread
xPSR: 0x61000000 pc: 0x2000002e msp: 0x000007c0
verified 120668 bytes in 0.810280s (145.431 KiB/s)
** Verified OK **
** Resetting Target **
shutdown command invoked
=========================================
```