### PR TITLE
Adding JLink Support for BBC micro:bit

### DIFF
--- a/boards/bbcmicrobit.json
+++ b/boards/bbcmicrobit.json
@@ -15,7 +15,8 @@
     "onboard_tools": [
       "cmsis-dap"
     ],
-    "svd_path": "nrf51.svd"
+    "svd_path": "nrf51.svd",
+    "jlink_device": "nRF51802_xxAA"
   },
   "frameworks": [
     "arduino",
@@ -28,7 +29,8 @@
     "protocol": "cmsis-dap",
     "protocols": [
       "cmsis-dap",
-      "mbed"
+      "mbed",
+      "jlink"
     ]
   },
   "url": "https://developer.mbed.org/platforms/Microbit/",

--- a/boards/bbcmicrobit.json
+++ b/boards/bbcmicrobit.json
@@ -16,7 +16,7 @@
       "cmsis-dap"
     ],
     "svd_path": "nrf51.svd",
-    "jlink_device": "nRF51802_xxAA"
+    "jlink_device": "nRF51822_xxAA"
   },
   "frameworks": [
     "arduino",

--- a/boards/bbcmicrobit_b.json
+++ b/boards/bbcmicrobit_b.json
@@ -12,7 +12,7 @@
       "cmsis-dap"
     ],
     "svd_path": "nrf51.svd",
-    "jlink_device": "nRF51802_xxAA"
+    "jlink_device": "nRF51822_xxAA"
   },
   "frameworks": [
     "mbed"

--- a/boards/bbcmicrobit_b.json
+++ b/boards/bbcmicrobit_b.json
@@ -11,7 +11,8 @@
     "onboard_tools": [
       "cmsis-dap"
     ],
-    "svd_path": "nrf51.svd"
+    "svd_path": "nrf51.svd",
+    "jlink_device": "nRF51802_xxAA"
   },
   "frameworks": [
     "mbed"
@@ -23,7 +24,8 @@
     "protocol": "cmsis-dap",
     "protocols": [
       "cmsis-dap",
-      "mbed"
+      "mbed",
+      "jlink"
     ]
   },
   "url": "https://developer.mbed.org/platforms/Microbit/",


### PR DESCRIPTION
BBC micro:bit supports Segger JLink OB via a Firmware Update on the on-board KL26Z MCU. More details here:

https://www.segger.com/products/debug-probes/j-link/models/other-j-links/bbc-microbit-j-link-upgrade/

This patch changes the boards metadata so it works with boards with the jlink-ob, provided one declares `upload_protocol` as `jlink`